### PR TITLE
docs: fix broken environments API reference and stale spark pool docstring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `docs/functions/items/environments.md` referenced the removed
+  `pyfabricops.items.environments_gen2` module (renamed to `environments` in
+  an earlier refactor), which made `mkdocs build` fail outright and broke
+  the entire generated API reference, not just that one page.
+- `create_workspace_custom_pool()` docstring documented a `workspace_custom_pool`
+  parameter that isn't part of its signature (copy-pasted from
+  `update_workspace_custom_pool`), and mislabeled `display_name` in the
+  example. Corrected the `Args`, `Returns`, and example to match the actual
+  function.
+
 ---
 
 ## [0.6.0] - 2026-05-06

--- a/docs/functions/items/environments.md
+++ b/docs/functions/items/environments.md
@@ -1,1 +1,1 @@
-::: pyfabricops.items.environments_gen2
+::: pyfabricops.items.environments

--- a/src/pyfabricops/items/spark.py
+++ b/src/pyfabricops/items/spark.py
@@ -160,8 +160,7 @@ def create_workspace_custom_pool(
 
     Args:
         workspace (str): The workspace name or ID.
-        workspace_custom_pool (str): The name or ID of the workspace custom pool to update.
-        display_name (str, optional): The new display name for the workspace custom pool.
+        display_name (str, optional): The display name for the new workspace custom pool.
         auto_scale_enabled (bool, optional): Whether auto-scaling is enabled.
         min_node_count (int, optional): The minimum number of nodes.
         max_node_count (int, optional): The maximum number of nodes.
@@ -174,13 +173,13 @@ def create_workspace_custom_pool(
             If False, returns a list of dictionaries.
 
     Returns:
-        (Union[DataFrame, Dict[str, Any], None]): The updated workspace custom pool details if successful, otherwise None.
+        (Union[DataFrame, Dict[str, Any], None]): The created workspace custom pool details if successful, otherwise None.
 
     Examples:
         ```python
         create_workspace_custom_pool(
             'MyProjectWorkspace',
-            'MyCustomPool',
+            'MyNewCustomPool',
             auto_scale_enabled=True,
             min_node_count=1,
             max_node_count=10,


### PR DESCRIPTION
Closes #78.

## Investigating the report

The issue says documentation for `create_workspace_custom_pool` "not found." Building the docs locally (`mkdocs build`) turned up two separate problems:

### 1. The whole API reference build is currently broken

`docs/functions/items/environments.md` contains:

```
::: pyfabricops.items.environments_gen2
```

That module was renamed to `pyfabricops.items.environments` in an earlier refactor (the file no longer exists in `src/pyfabricops/items/`). `mkdocs build` aborts on this with:

```
ERROR - mkdocstrings: pyfabricops.items.environments_gen2 could not be found
ERROR - Error reading page 'functions/items/environments.md':
ERROR - Could not collect 'pyfabricops.items.environments_gen2'
Aborted with a BuildError!
```

This isn't a "skip one page and continue" error — it aborts the entire build, so if the published docs site is built the same way, none of the API reference (including the `create_workspace_custom_pool` page you were looking for) would be current or even present.

Fixed by updating the `:::` directive to the current module path (`pyfabricops.items.environments`). Confirmed the full site now builds cleanly with `mkdocs build` (exit 0, no errors).

### 2. `create_workspace_custom_pool`'s own docstring was wrong

Once the build was unblocked, I checked the actual rendered page for this function. Its docstring's `Args` section documented a `workspace_custom_pool` parameter that isn't part of the function's signature at all — it was copy-pasted from the neighboring `update_workspace_custom_pool` function. The example also mislabeled `display_name` as if it were naming an *existing* pool to update, rather than the *new* pool being created.

Fixed the `Args`, `Returns`, and example in `create_workspace_custom_pool()`'s docstring to match its real signature.

## Verification

- `mkdocs build` — now completes successfully (previously aborted).
- Manually inspected the generated HTML for `create_workspace_custom_pool` — renders with the corrected signature and description.
- `ruff check` / `ruff format --check` on both changed files — clean.
- `pytest tests` — 36 passed, 1 skipped (pre-existing skip, unrelated).

## Note

While confirming the fix, `mkdocs build` also surfaced several pre-existing `griffe` warnings about other functions' docstrings listing parameters that don't exist in their signatures (`deployment_pipelines.py`, `domains.py`, `data_pipelines.py`, `dataflows_gen1.py`, `reports.py`, `semantic_models.py`, `decorators.py`, `utils.py`) — the same class of copy-paste drift as `create_workspace_custom_pool`. Left those out of this PR to keep it focused per CONTRIBUTING.md, but happy to open a follow-up if useful.